### PR TITLE
RL loot council data parsing and item name fetching

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -35,12 +35,12 @@ class LootItemData:
             self.original_owner = self.original_owner.replace("-" + self.realm_name, '')
 
     def __str__(self):
+
         if self.recipient != self.original_owner:
-            return f"{self.received_time.strftime('%d.%m %H:%M')} [{self.original_owner} >> {self.recipient}] " \
-                   f"received [url={self.item_url}][{self.item_name}][/url] ({self.response}) from " \
-                   f"{self.boss_name} in {self.instance_name}"
+            name = f"{self.original_owner} >> {self.recipient}"
         else:
-            return f"{self.received_time.strftime('%d.%m %H:%M')} [{self.recipient}] received [url={self.item_url}]" \
+            name = f"{self.recipient}"
+        return f"{self.received_time.strftime('%d.%m %H:%M')} [{name}] received [url={self.item_url}]" \
                    f"[{self.item_name}][/url] ({self.response}) from {self.boss_name} in {self.instance_name}"
 
 
@@ -399,7 +399,7 @@ class Backend:
                                 instance_name=loot_data['instance'],
                                 item_id=loot_data['itemID'],
                                 item_url=url,
-                                item_name=self.bnet.getItemName(item_id),
+                                # item_name=self.bnet.getItemName(item_id),
                                 realm_name="Stormscale")
             loot_list.append(loot)
 

--- a/backend.py
+++ b/backend.py
@@ -399,7 +399,7 @@ class Backend:
                                 instance_name=loot_data['instance'],
                                 item_id=loot_data['itemID'],
                                 item_url=url,
-                                # item_name=self.bnet.getItemName(item_id),
+                                item_name=self.bnet.getItemName(item_id),
                                 realm_name="Stormscale")
             loot_list.append(loot)
 

--- a/backend.py
+++ b/backend.py
@@ -315,7 +315,20 @@ class Backend:
 		return info
 		
 
-		
+	def getLootLog(self) -> List[str]:
+		"""
+		Fetches the loot log from exported RClootcouncil file
+		:return:
+			List containing the rows of BBCode for the equipment log
+		"""
+		export_filename = ""
+		loot_list = []
+		with open(export_filename, 'rb') as f:
+			lines = f.readlines()
+			for line in lines:
+				loot_list.append(line)
+
+		return loot_list
 
 
 if __name__ == "__main__":

--- a/backend.py
+++ b/backend.py
@@ -17,6 +17,9 @@ import os
 
 @dataclass
 class LootItemData:
+    """
+    Contains data about a loot item in an RClootcouncil session.
+    """
     item_name: str = "<insert name here>"
     recipient: str = ""
     recipient_class: str = ""
@@ -30,13 +33,18 @@ class LootItemData:
     realm_name: str = "Stormscale"
 
     def __post_init__(self):
+        """
+        Remove realm names from characters from the same realm but leave them for PUGs.
+        """
         if self.realm_name in self.recipient:
             self.recipient = self.recipient.replace("-" + self.realm_name, '')
         if self.realm_name in self.original_owner:
             self.original_owner = self.original_owner.replace("-" + self.realm_name, '')
 
     def __str__(self):
-
+        """
+        String representation of the loot item for easier handling.
+        """
         if self.recipient != self.original_owner:
             name = f"{self.original_owner} >> {self.recipient}"
         else:
@@ -355,15 +363,19 @@ class Backend:
 
         return info
 
-    def getLootLog(self, loot_file: Union[str, List[str]], reversed: bool = True) -> List[LootItemData]:
+    def getLootLog(self, loot_file: Union[str, List[str]], time_descending: bool = False) -> List[LootItemData]:
         """
-        Fetches the loot log from exported RClootcouncil file
-        :param loot_file:
-            Filename, list of filenames or directory containing .json files that contain the loot data
-        :param reversed:
-            If reversed, loot is sorted in time-ascending order
-        :return:
-            List containing the rows of BBCode for the equipment log
+        Fetches RC loot council loot data from .csv file(s) and returns a list of LootItemData objects in time-sorted
+        order from latest to oldest.
+
+        Args:
+            loot_file (:obj: `str`, :obj: `list` of :obj: `str`): Contains the filename, directory name or
+                list of filenames containing the data
+            time_descending (bool, optional): Set to true to sort from oldest to newest. Otherwise sorts from
+                newest to oldest.
+
+        Returns:
+            List: :obj: `LootItemData` objects sorted by time.
         """
         # Pull data from file(s)
         pulled_data = []
@@ -411,7 +423,7 @@ class Backend:
                                 realm_name="Stormscale")
             loot_list.append(loot)
 
-        loot_list.sort(key=operator.attrgetter('received_time'), reverse=reversed)
+        loot_list.sort(key=operator.attrgetter('received_time'), reverse=not time_descending)
 
         return loot_list
 

--- a/backend.py
+++ b/backend.py
@@ -376,7 +376,7 @@ class Backend:
                         pulled_data.append(dict(row))
         elif os.path.isdir(loot_file):
             files = [os.path.join(loot_file, f) for f in os.listdir(loot_file) if
-                     os.path.isfile(os.path.join(loot_file, f)) and '.json' in f]
+                     os.path.isfile(os.path.join(loot_file, f)) and '.csv' in f]
             for file in files:
                 with open(file) as f:
                     reader = csv.DictReader(f)

--- a/backend.py
+++ b/backend.py
@@ -13,395 +13,384 @@ import time
 from dotenv import load_dotenv
 import os
 
+
 @dataclass
 class LootItemData:
-	item_name: str = "<insert name here>"
-	recipient: str = ""
-	recipient_class: str = ""
-	received_time: datetime = None
-	original_owner: str = ""
-	response: str = ""
-	boss_name: str = ""
-	instance_name: str = ""
-	item_id: int = 0
-	item_url: str = ""
-	realm_name: str = "Stormscale"
+    item_name: str = "<insert name here>"
+    recipient: str = ""
+    recipient_class: str = ""
+    received_time: datetime = None
+    original_owner: str = ""
+    response: str = ""
+    boss_name: str = ""
+    instance_name: str = ""
+    item_id: int = 0
+    item_url: str = ""
+    realm_name: str = "Stormscale"
 
-	def __post_init__(self):
-		if self.realm_name in self.recipient:
-			self.recipient = self.recipient.replace("-" + self.realm_name, '')
-		if self.realm_name in self.original_owner:
-			self.original_owner = self.original_owner.replace("-" + self.realm_name, '')
+    def __post_init__(self):
+        if self.realm_name in self.recipient:
+            self.recipient = self.recipient.replace("-" + self.realm_name, '')
+        if self.realm_name in self.original_owner:
+            self.original_owner = self.original_owner.replace("-" + self.realm_name, '')
 
-	def __str__(self):
-		if self.recipient != self.original_owner:
-			return f"{self.received_time.strftime('%d.%m %H:%M')} [{self.original_owner} >> {self.recipient}] " \
-					f"received [url={self.item_url}][{self.item_name}][/url] ({self.response}) from " \
-					f"{self.boss_name} in {self.instance_name}"
-		else:
-			return f"{self.received_time.strftime('%d.%m %H:%M')} [{self.recipient}] received [url={self.item_url}]" \
-					f"[{self.item_name}][/url] ({self.response}) from {self.boss_name} in {self.instance_name}"
+    def __str__(self):
+        if self.recipient != self.original_owner:
+            return f"{self.received_time.strftime('%d.%m %H:%M')} [{self.original_owner} >> {self.recipient}] " \
+                   f"received [url={self.item_url}][{self.item_name}][/url] ({self.response}) from " \
+                   f"{self.boss_name} in {self.instance_name}"
+        else:
+            return f"{self.received_time.strftime('%d.%m %H:%M')} [{self.recipient}] received [url={self.item_url}]" \
+                   f"[{self.item_name}][/url] ({self.response}) from {self.boss_name} in {self.instance_name}"
 
 
 class Backend:
-
-	db = ""
-	bnet = ""
-	rio = ""
-	wcl = ""
-	realm = ""
-	region = ""
-
-	def __init__(self):
-		load_dotenv()
-		self.db = Database()
-		self.bnet = Bnet()
-		self.rio = RIO()
-		self.wcl = WCL()
-		self.region = os.getenv("WOWREGION")
-		self.realm = os.getenv("WOWREALM")
-
-	def getView(self) -> List[Dict[str, str]]:
-		"""
-		Get data for roster table
-		"""
-
-		def sorter(item) -> Tuple[int, str]:
-			roleprio = 0
-			if item["Role"] == "Tank":
-				roleprio = 1
-			elif item["Role"] == "Healer":
-				roleprio = 2
-			elif item["Role"] == "DPS":
-				roleprio = 3
-			else:
-				roleprio = 4
-
-			return (roleprio, item["name"])
-		
-		data = self.db.getIndex()
-
-		listed = sorted(data, key=sorter)
-
-		return listed
-		
-	def getBlog(self):
-		"""
-		Get blog posts
-		"""
-		data = self.db.getBlog()
-		return data
-
-	def getSingleBlog(self, id: str):
-		"""
-		Get a single blog post with id
-		"""
-		# TODO create a db.py method for getting single blog, this is ugly
-		return self.db.db.blog.find_one({"id": id})
-
-
-	def getLogs(self):
-		"""
-		Get most recent logs for guild from WCL
-		"""
-
-		data = json.loads(self.wcl.getGuildLogs())
-
-		if "error" in data:
-			
-			data = [{"title": "Error!", "start": data["error"], "id": " "}]
-
-		elif len(data) > 10:
-			data = data[0:10]
-
-		for row in data:
-			row["start"] = time.strftime('%Y-%m-%d', time.localtime(int(row["start"]/1000)))
-
-		return data
-
-	def updateView(self):
-		"""
-		Update view tables from db
-		"""
-		pass
-
-	def addPlayer(self, player: Dict[str, str]) -> bool:
-		"""
-		Add player to roster manually
-		"""
-
-		self.db.addPlayer(player["name"],player["Class"],player["Role"])
-
-		return True
-		
-
-	def removePlayer(self, player: Dict[str, str]) -> bool:
-		"""
-		Remove player from roster
-		"""
-		query = {
-			"name": player["name"]
-		}
-
-		collection = ""
-
-		if player["automated"]:
-			collection = "autoplayers"
-
-		else:
-			collection = "players"
-
-		res = self.db.remove(collection, query)
-
-		return res
-
-	def updateRoster(self):
-		"""
-		Update roster data
-		"""
-		# get raiders from bnet
-		roster = self.bnet.getRoster()
-		manuals = self.db.getManualPlayers()
-
-		print(roster)
-		print(manuals)
-
-		# iterate over players and get full data
-		for i in roster:
-			tmp = { "name": "",
-					"Class": "",
-					"Role": "",
-					"ilv": 0.0,
-					"Weekly": 0,
-					"rio": 0.0,
-					"wcln": 0.0,
-					"wclh": 0.0,
-					"wclm": 0.0
-			}
-
-			name = i["name"]
-			cclass = i["class"]
-
-			tmp["name"] = name
-			tmp["Class"] = cclass
-			tmp["Role"] = self.db.findRole(name)
-
-			print("Getting ilv from battle.net profile for " + name)
-			bnetprofile = self.bnet.getCharacterProfile(name)
-			tmp["ilv"] = bnetprofile["average_item_level"]
-
-			print("Getting m+ data from raider.io for " + name)
-			rioprofile = self.rio.getProfile(name)
-
-			# will return empty list if there are no runs for the week
-			if len(rioprofile["mythic_plus_weekly_highest_level_runs"]) == 0:
-				tmp["Weekly"] = 0
-			else:
-				tmp["Weekly"] = int(rioprofile["mythic_plus_weekly_highest_level_runs"][0]["mythic_level"])
-
-			# in case of no data, should still return 0 as a score
-			tmp["rio"] = float( rioprofile["mythic_plus_scores_by_season"][0]["scores"]["all"] )
-
-
-			wclperf = self.wcl.getPlayerAvg(name)
-
-			tmp["wcln"] = wclperf["avgN"]
-			tmp["wclh"] = wclperf["avgH"]
-			tmp["wclm"] = wclperf["avgM"]
-
-			dbquery = {"name": name}
-			dbnewdata = { "$set": tmp }
-			
-			# push updated automated players to DB
-			# TODO create a method for updating in db.py this is ugly
-			self.db.db.autoplayers.update_one(dbquery, dbnewdata, upsert=True)
-		
-
-		# TODO refactor this to have only one loop / function call
-		# ugly repeating loop
-
-		for i in manuals:
-			tmp = { "name": "",
-					"Class": "",
-					"Role": "",
-					"ilv": 0.0,
-					"Weekly": 0,
-					"rio": 0.0,
-					"wcln": 0.0,
-					"wclh": 0.0,
-					"wclm": 0.0
-			}
-
-			name = i["name"]
-			cclass = i["Class"]
-
-			tmp["name"] = name
-			tmp["Class"] = cclass
-			tmp["Role"] = self.db.findRole(name)
-
-			print("Getting ilv from battle.net profile for " + name)
-			bnetprofile = self.bnet.getCharacterProfile(name)
-			tmp["ilv"] = bnetprofile["average_item_level"]
-
-			print("Getting m+ data from raider.io for " + name)
-			rioprofile = self.rio.getProfile(name)
-			# will return empty list if there are no runs for the week
-			if len(rioprofile["mythic_plus_weekly_highest_level_runs"]) == 0:
-				tmp["Weekly"] = 0
-			else:
-				tmp["Weekly"] = int(rioprofile["mythic_plus_weekly_highest_level_runs"][0]["mythic_level"])
-			
-			tmp["rio"] = float( rioprofile["mythic_plus_scores_by_season"][0]["scores"]["all"] )
-
-
-			wclperf = self.wcl.getPlayerAvg(name)
-
-			tmp["wcln"] = wclperf["avgN"]
-			tmp["wclh"] = wclperf["avgH"]
-			tmp["wclm"] = wclperf["avgM"]
-
-			dbquery = {"name": name}
-			dbnewdata =  { "$set": tmp }
-			
-			# push updated automated players to DB
-			# TODO create a method for updating in db.py this is ugly
-			self.db.db.players.update_one(dbquery, dbnewdata, upsert=True)
-
-
-		#Update updating time to settings
-		#TODO this needs methods, ugly
-		print("Setting update timestamp to " + str(int(time.time())) )
-		response = self.db.db.settings.update_one({}, {"$set": {"timestamp": int(time.time()) }}, upsert=False)
-		print("Modified " + str(response.modified_count) + " entries")
-
-		# TODO implement some kind of error handling and return False in
-		# case there is an error
-		return True
-
-	def login(self, usr: str, pwd: str):
-		"""
-		Check login information
-		"""
-
-		settings = self.db.getSettings()
-
-		boolusr=False
-		boolpwd=False
-
-		# check admin credentials
-		if settings["adminname"] == usr:
-			boolusr=True
-		if settings["adminpwd"] == pwd:
-			boolpwd=True
-
-		if boolusr and boolpwd:
-			return boolusr, boolpwd
-		else:
-			#check additional login table for officers etc
-			#TODO
-			return boolusr, boolpwd
-
-	def post(self, title: str, content: str):
-		r = self.db.postBlog(title, content)
-
-		return r
-
-	def getUpdateTimestamp(self):
-		return self.db.getSettings()["timestamp"]
-
-
-	def editPlayerRole(self, playername: str, playerrole: str, automated: bool):
-		self.db.updateRole(playername, playerrole, automated)
-
-
-	def getSideBar(self):
-		"""
-		Gets data for sidebar.
-
-		Initializes a sidebar element list.
-		Calls rio.py method getRaidProgress() to get raid progress from raider.io
-
-		Returns:
-			List of sidebar entities, where [0] is reserved for raid progress and [1] for raidaudit version
-		"""
-		sidebar = [{"progress": "NA"}, {"version": "NA"}]
-
-		progress = self.rio.getRaidProgress()
-		sidebar[0] = progress
-		return sidebar
-		
-
-	def getLinkInfo(self):
-		"""
-		Get realm, region and locale data to generate links to roster table
-		"""
-		info = {
-			"locale": "en-gb",
-			"region": self.region,
-			"realm": self.realm
-		}
-
-		# TODO support all regions? now only eu/us
-		if info["region"] == "us":
-			info["locale"] = "en-us"
-
-		return info
-
-	def getLootLog(self, loot_file: Union[str, List[str]], reversed: bool = True) -> List[LootItemData]:
-		"""
-		Fetches the loot log from exported RClootcouncil file
-		:param loot_filename:
-			Filename, list of filenames or directory containing .json files that contain the loot data
-		:param reversed:
-			If reversed, loot is sorted in time-ascending order
-		:return:
-			List containing the rows of BBCode for the equipment log
-		"""
-		# Pull data from file(s)
-		pulled_data = []
-		if isinstance(loot_file, list):
-			for filename in loot_file:
-				with open(filename, 'rb') as f:
-					pulled_data  += json.load(f)
-		elif os.path.isdir(loot_file):
-			files = [os.path.join(loot_file, f) for f in os.listdir(loot_file) if os.path.isfile(os.path.join(loot_file, f)) and '.json' in f]
-			for file in files:
-				with open(file, 'rb') as f:
-					pulled_data += json.load(f)
-		elif os.path.isfile(loot_file):
-			with open(loot_file, 'rb') as f:
-				pulled_data += json.load(f)
-
-		# parse data in file(s)
-		loot_list = []
-		for loot_data in pulled_data:
-			itemstring = loot_data['itemString']
-			vals = itemstring.split(':')
-			item_id = loot_data['itemID']
-			bonuses = vals[14:]
-			url = f"https://www.wowhead.com/item={item_id}&bonus={':'.join(bonuses)}"
-			date_string = loot_data['date'] + " " + loot_data['time']
-			date = datetime.strptime(date_string, '%d/%m/%y %H:%M:%S')
-			loot = LootItemData(recipient=loot_data['player'],
-								recipient_class=loot_data['class'],
-								received_time=date,
-								original_owner=loot_data['owner'],
-								response=loot_data['response'],
-								boss_name=loot_data['boss'],
-								instance_name=loot_data['instance'],
-								item_id=loot_data['itemID'],
-								item_url=url,
-								realm_name="Stormscale")
-			loot_list.append(loot)
-
-		loot_list.sort(key=operator.attrgetter('received_time'), reverse=True)
-
-		return loot_list
+    db = ""
+    bnet = ""
+    rio = ""
+    wcl = ""
+    realm = ""
+    region = ""
+
+    def __init__(self):
+        load_dotenv()
+        self.db = Database()
+        self.bnet = Bnet()
+        self.rio = RIO()
+        self.wcl = WCL()
+        self.region = os.getenv("WOWREGION")
+        self.realm = os.getenv("WOWREALM")
+
+    def getView(self) -> List[Dict[str, str]]:
+        """
+        Get data for roster table
+        """
+
+        def sorter(item) -> Tuple[int, str]:
+            roleprio = 0
+            if item["Role"] == "Tank":
+                roleprio = 1
+            elif item["Role"] == "Healer":
+                roleprio = 2
+            elif item["Role"] == "DPS":
+                roleprio = 3
+            else:
+                roleprio = 4
+
+            return (roleprio, item["name"])
+
+        data = self.db.getIndex()
+
+        listed = sorted(data, key=sorter)
+
+        return listed
+
+    def getBlog(self):
+        """
+        Get blog posts
+        """
+        data = self.db.getBlog()
+        return data
+
+    def getSingleBlog(self, id: str):
+        """
+        Get a single blog post with id
+        """
+        # TODO create a db.py method for getting single blog, this is ugly
+        return self.db.db.blog.find_one({"id": id})
+
+    def getLogs(self):
+        """
+        Get most recent logs for guild from WCL
+        """
+
+        data = json.loads(self.wcl.getGuildLogs())
+
+        if "error" in data:
+
+            data = [{"title": "Error!", "start": data["error"], "id": " "}]
+
+        elif len(data) > 10:
+            data = data[0:10]
+
+        for row in data:
+            row["start"] = time.strftime('%Y-%m-%d', time.localtime(int(row["start"] / 1000)))
+
+        return data
+
+    def updateView(self):
+        """
+        Update view tables from db
+        """
+        pass
+
+    def addPlayer(self, player: Dict[str, str]) -> bool:
+        """
+        Add player to roster manually
+        """
+
+        self.db.addPlayer(player["name"], player["Class"], player["Role"])
+
+        return True
+
+    def removePlayer(self, player: Dict[str, str]) -> bool:
+        """
+        Remove player from roster
+        """
+        query = {
+            "name": player["name"]
+        }
+
+        collection = ""
+
+        if player["automated"]:
+            collection = "autoplayers"
+
+        else:
+            collection = "players"
+
+        res = self.db.remove(collection, query)
+
+        return res
+
+    def updateRoster(self):
+        """
+        Update roster data
+        """
+        # get raiders from bnet
+        roster = self.bnet.getRoster()
+        manuals = self.db.getManualPlayers()
+
+        print(roster)
+        print(manuals)
+
+        # iterate over players and get full data
+        for i in roster:
+            tmp = {"name": "",
+                   "Class": "",
+                   "Role": "",
+                   "ilv": 0.0,
+                   "Weekly": 0,
+                   "rio": 0.0,
+                   "wcln": 0.0,
+                   "wclh": 0.0,
+                   "wclm": 0.0
+                   }
+
+            name = i["name"]
+            cclass = i["class"]
+
+            tmp["name"] = name
+            tmp["Class"] = cclass
+            tmp["Role"] = self.db.findRole(name)
+
+            print("Getting ilv from battle.net profile for " + name)
+            bnetprofile = self.bnet.getCharacterProfile(name)
+            tmp["ilv"] = bnetprofile["average_item_level"]
+
+            print("Getting m+ data from raider.io for " + name)
+            rioprofile = self.rio.getProfile(name)
+
+            # will return empty list if there are no runs for the week
+            if len(rioprofile["mythic_plus_weekly_highest_level_runs"]) == 0:
+                tmp["Weekly"] = 0
+            else:
+                tmp["Weekly"] = int(rioprofile["mythic_plus_weekly_highest_level_runs"][0]["mythic_level"])
+
+            # in case of no data, should still return 0 as a score
+            tmp["rio"] = float(rioprofile["mythic_plus_scores_by_season"][0]["scores"]["all"])
+
+            wclperf = self.wcl.getPlayerAvg(name)
+
+            tmp["wcln"] = wclperf["avgN"]
+            tmp["wclh"] = wclperf["avgH"]
+            tmp["wclm"] = wclperf["avgM"]
+
+            dbquery = {"name": name}
+            dbnewdata = {"$set": tmp}
+
+            # push updated automated players to DB
+            # TODO create a method for updating in db.py this is ugly
+            self.db.db.autoplayers.update_one(dbquery, dbnewdata, upsert=True)
+
+        # TODO refactor this to have only one loop / function call
+        # ugly repeating loop
+
+        for i in manuals:
+            tmp = {"name": "",
+                   "Class": "",
+                   "Role": "",
+                   "ilv": 0.0,
+                   "Weekly": 0,
+                   "rio": 0.0,
+                   "wcln": 0.0,
+                   "wclh": 0.0,
+                   "wclm": 0.0
+                   }
+
+            name = i["name"]
+            cclass = i["Class"]
+
+            tmp["name"] = name
+            tmp["Class"] = cclass
+            tmp["Role"] = self.db.findRole(name)
+
+            print("Getting ilv from battle.net profile for " + name)
+            bnetprofile = self.bnet.getCharacterProfile(name)
+            tmp["ilv"] = bnetprofile["average_item_level"]
+
+            print("Getting m+ data from raider.io for " + name)
+            rioprofile = self.rio.getProfile(name)
+            # will return empty list if there are no runs for the week
+            if len(rioprofile["mythic_plus_weekly_highest_level_runs"]) == 0:
+                tmp["Weekly"] = 0
+            else:
+                tmp["Weekly"] = int(rioprofile["mythic_plus_weekly_highest_level_runs"][0]["mythic_level"])
+
+            tmp["rio"] = float(rioprofile["mythic_plus_scores_by_season"][0]["scores"]["all"])
+
+            wclperf = self.wcl.getPlayerAvg(name)
+
+            tmp["wcln"] = wclperf["avgN"]
+            tmp["wclh"] = wclperf["avgH"]
+            tmp["wclm"] = wclperf["avgM"]
+
+            dbquery = {"name": name}
+            dbnewdata = {"$set": tmp}
+
+            # push updated automated players to DB
+            # TODO create a method for updating in db.py this is ugly
+            self.db.db.players.update_one(dbquery, dbnewdata, upsert=True)
+
+        # Update updating time to settings
+        # TODO this needs methods, ugly
+        print("Setting update timestamp to " + str(int(time.time())))
+        response = self.db.db.settings.update_one({}, {"$set": {"timestamp": int(time.time())}}, upsert=False)
+        print("Modified " + str(response.modified_count) + " entries")
+
+        # TODO implement some kind of error handling and return False in
+        # case there is an error
+        return True
+
+    def login(self, usr: str, pwd: str):
+        """
+        Check login information
+        """
+
+        settings = self.db.getSettings()
+
+        boolusr = False
+        boolpwd = False
+
+        # check admin credentials
+        if settings["adminname"] == usr:
+            boolusr = True
+        if settings["adminpwd"] == pwd:
+            boolpwd = True
+
+        if boolusr and boolpwd:
+            return boolusr, boolpwd
+        else:
+            # check additional login table for officers etc
+            # TODO
+            return boolusr, boolpwd
+
+    def post(self, title: str, content: str):
+        r = self.db.postBlog(title, content)
+
+        return r
+
+    def getUpdateTimestamp(self):
+        return self.db.getSettings()["timestamp"]
+
+    def editPlayerRole(self, playername: str, playerrole: str, automated: bool):
+        self.db.updateRole(playername, playerrole, automated)
+
+    def getSideBar(self):
+        """
+        Gets data for sidebar.
+
+        Initializes a sidebar element list.
+        Calls rio.py method getRaidProgress() to get raid progress from raider.io
+
+        Returns:
+            List of sidebar entities, where [0] is reserved for raid progress and [1] for raidaudit version
+        """
+        sidebar = [{"progress": "NA"}, {"version": "NA"}]
+
+        progress = self.rio.getRaidProgress()
+        sidebar[0] = progress
+        return sidebar
+
+    def getLinkInfo(self):
+        """
+        Get realm, region and locale data to generate links to roster table
+        """
+        info = {
+            "locale": "en-gb",
+            "region": self.region,
+            "realm": self.realm
+        }
+
+        # TODO support all regions? now only eu/us
+        if info["region"] == "us":
+            info["locale"] = "en-us"
+
+        return info
+
+    def getLootLog(self, loot_file: Union[str, List[str]], reversed: bool = True) -> List[LootItemData]:
+        """
+        Fetches the loot log from exported RClootcouncil file
+        :param loot_file:
+            Filename, list of filenames or directory containing .json files that contain the loot data
+        :param reversed:
+            If reversed, loot is sorted in time-ascending order
+        :return:
+            List containing the rows of BBCode for the equipment log
+        """
+        # Pull data from file(s)
+        pulled_data = []
+        if isinstance(loot_file, list):
+            for filename in loot_file:
+                with open(filename, 'rb') as f:
+                    pulled_data += json.load(f)
+        elif os.path.isdir(loot_file):
+            files = [os.path.join(loot_file, f) for f in os.listdir(loot_file) if
+                     os.path.isfile(os.path.join(loot_file, f)) and '.json' in f]
+            for file in files:
+                with open(file, 'rb') as f:
+                    pulled_data += json.load(f)
+        elif os.path.isfile(loot_file):
+            with open(loot_file, 'rb') as f:
+                pulled_data += json.load(f)
+
+        # parse data in file(s)
+        loot_list = []
+        for loot_data in pulled_data:
+            itemstring = loot_data['itemString']
+            vals = itemstring.split(':')
+            item_id = loot_data['itemID']
+            bonuses = vals[14:]
+            url = f"https://www.wowhead.com/item={item_id}&bonus={':'.join(bonuses)}"
+            date_string = loot_data['date'] + " " + loot_data['time']
+            date = datetime.strptime(date_string, '%d/%m/%y %H:%M:%S')
+            loot = LootItemData(recipient=loot_data['player'],
+                                recipient_class=loot_data['class'],
+                                received_time=date,
+                                original_owner=loot_data['owner'],
+                                response=loot_data['response'],
+                                boss_name=loot_data['boss'],
+                                instance_name=loot_data['instance'],
+                                item_id=loot_data['itemID'],
+                                item_url=url,
+                                realm_name="Stormscale")
+            loot_list.append(loot)
+
+        loot_list.sort(key=operator.attrgetter('received_time'), reverse=True)
+
+        return loot_list
 
 
 if __name__ == "__main__":
-	back = Backend()
-	print(back.getUpdateTimestamp())
-	
-	
-
+    back = Backend()
+    print(back.getUpdateTimestamp())

--- a/backend.py
+++ b/backend.py
@@ -399,6 +399,7 @@ class Backend:
                                 instance_name=loot_data['instance'],
                                 item_id=loot_data['itemID'],
                                 item_url=url,
+                                item_name=self.bnet.getItemName(item_id),
                                 realm_name="Stormscale")
             loot_list.append(loot)
 

--- a/backend.py
+++ b/backend.py
@@ -403,7 +403,7 @@ class Backend:
                                 realm_name="Stormscale")
             loot_list.append(loot)
 
-        loot_list.sort(key=operator.attrgetter('received_time'), reverse=True)
+        loot_list.sort(key=operator.attrgetter('received_time'), reverse=reversed)
 
         return loot_list
 

--- a/bnet.py
+++ b/bnet.py
@@ -158,11 +158,13 @@ class Bnet:
 
     def getItemName(self, itemid: Union[int, List[int]]):
         """
-        get item name from the Bnet endpoint
-        :param itemid:
-            ID of the item to fetch
-        :return:
-            The name of the item
+        Get item name from the bnet endpoint
+
+        Args:
+            itemid (int, :obj: `list` of int): item ID or a list of item IDs to query from the endpoint.
+
+        Returns:
+            Item name or a list of item names corresponding to the arg item IDs.
         """
 
         print(f"Getting item name for {itemid}...")

--- a/bnet.py
+++ b/bnet.py
@@ -1,5 +1,5 @@
 import time
-from typing import Dict
+from typing import Dict, List, Union
 
 import requests
 from dotenv import load_dotenv
@@ -156,7 +156,7 @@ class Bnet:
 
         return req
 
-    def getItemName(self, itemid: int):
+    def getItemName(self, itemid: Union[int, List[int]]):
         """
         get item name from the Bnet endpoint
         :param itemid:
@@ -168,14 +168,30 @@ class Bnet:
         print(f"Getting item name for {itemid}...")
 
         self._token = self.getAccessToken()
-        reqUrl = f"{self._apiurl}data/wow/item/{itemid}"
-        print(f"bnet.getItemName {itemid}")
-        req = requests.get(reqUrl)
-        print(f"bnet.getItemName {req.status_code}")
-        req = req.json
-
-        return req['name']
-
+        if not isinstance(itemid, list):
+            reqUrl = f"{self._apiurl}data/wow/item/{itemid}?namespace={self._namespace}" \
+                     f"&locale={self._locale}&access_token={self._token}"
+            print(reqUrl)
+            print(f"bnet.getItemName {itemid}")
+            req = requests.get(reqUrl)
+            print(f"bnet.getItemName {req.status_code}")
+            if req.status_code != 200:
+                return ""
+            else:
+                req = req.json()
+                return req['name']
+        else:
+            item_list = []
+            for item in itemid:
+                reqUrl = f"{self._apiurl}data/wow/item/{item}?namespace={self._namespace}" \
+                         f"&locale={self._locale}&access_token={self._token}"
+                print(reqUrl)
+                print(f"bnet.getItemName {item}")
+                req = requests.get(reqUrl)
+                print(f"bnet.getItemName {req.status_code}")
+                if req.status_code == 200:
+                    item_list.append(req.json()['name'])
+            return item_list
 
 if __name__ == "__main__":
     print("Running as main, testing..")

--- a/bnet.py
+++ b/bnet.py
@@ -148,7 +148,25 @@ class Bnet:
 
 		return req
 
+	def getItemName(self, itemid: int):
+		"""
+		get item name from the Bnet endpoint
+		:param itemid:
+			ID of the item to fetch
+		:return:
+			The name of the item
+		"""
 
+		print(f"Getting item name for {itemid}...")
+
+		self._token = self.getAccessToken()
+		reqUrl = f"{self._apiurl}data/wow/item/{itemid}"
+		print(f"bnet.getItemName {itemid}")
+		req = requests.get(reqUrl)
+		print(f"bnet.getItemName {req.status_code}")
+		req = req.json
+
+		return req['name']
 	
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -100,6 +100,21 @@
   </div>
 </div>
 
+<div class="card">
+  <div class="card-body">
+
+    <h5 class="card-title">Loot log</h5>
+    <table class="table table-striped table-dark">
+      {% for row in loots %}
+        <tr>
+          <td> {{ row }} </td>
+        </tr>
+      {% endfor %}
+
+    </table>
+
+  </div>
+</div>
 
 <script src="static/scripts/coloring.js"></script>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -100,21 +100,6 @@
   </div>
 </div>
 
-<div class="card">
-  <div class="card-body">
-
-    <h5 class="card-title">Loot log</h5>
-    <table class="table table-striped table-dark">
-      {% for row in loots %}
-        <tr>
-          <td> {{ row }} </td>
-        </tr>
-      {% endfor %}
-
-    </table>
-
-  </div>
-</div>
 
 <script src="static/scripts/coloring.js"></script>
 


### PR DESCRIPTION
Added function to backend that parses data from RC loot council logs as per #12. It takes the CSV files that can be exported from rc loot council and creates a list of LootItemData dataclasses containing all the useful info about the items including wowhead links with full bonuses. 

Also added a function to Bnet that can fetch item names from blizzard endpoint in either single runs or from a list of item IDs. Runs kinda slow and was only a temporary solution to a problem but I left it in there in case there might be any use for it later down the line.