### PR TITLE
Attendance data handling changed considerably

### DIFF
--- a/attendancedata.py
+++ b/attendancedata.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class AttendanceData:
+    """
+    Contains data about the attendance of a player
+    """
+    player_name: str = ""
+    raid_id: int = 0
+    raid_name: str = ""
+    present_total: int = 0
+    present_active: int = 0
+    present_benched: int = 0
+
+    def __str__(self):
+        return f"{self.player_name}: {self.present_total} ({self.present_active}/{self.present_benched})"

--- a/doc/database.txt
+++ b/doc/database.txt
@@ -48,3 +48,28 @@ plain text.
   "adminname": string	-- Username for admin login
   "adminpwd": string	-- Password for admin login
 }
+
+
+---------------
+
+attendance data
+This collection stores data about player attendance
+in various raids. It contains two different kinds of data,
+log metadata and attendance.
+
+log metadata:
+{
+  "tag": string         -- [META]
+  "log_id": string      -- WCL log id
+  "zone_id": int        -- zone id of the raid in question
+  "raid_name": string   -- raid name as a string
+  "start_time": int
+}
+player data:
+{
+  "tag": string             -- [PLAYER]
+  "log_id": string          -- WCL log id that this document is related to
+  "name": string            -- Player name
+  "player_class": string    -- player character class
+  "benched": bool          -- Whether the player was benched or not
+}


### PR DESCRIPTION
Re-wrote some of the code related to attendance and made it store the attendance data in DB for #13. Haven't system-tested the whole thing but individual parts have been tested to work. Attendance data can now be refreshed from WCL with updateAttendance() in the backend, though the wclg.getAttendance() might need to be modified to allow for full update. My understanding is that wclg.getAttendance probably only fetches some 16 raid's worth of attendance data at once and you'd have to deal with the pagination to get it all.