### PR TITLE
Re-try with code that just re-formats the WCL data

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -441,14 +441,10 @@ class Backend:
         """Gets attendance data from WCL GraphQL API
 
         Returns:
-            A Dictionary in the shape of ...
-            {
-                raid_id: {
-                        player_name: [
-                            int
-                        ]
-                    }
-            }
+            headers (list): contains the timestamps for each log in each raid
+            attendance (dict): contains player attendance for each log of each raid
+            token (str): query token
+            percentages (dict): contains player attendance % for each raid
         """
 
         settings = self.db.getSettings()

--- a/backend.py
+++ b/backend.py
@@ -473,11 +473,9 @@ class Backend:
                 raid_att[player].append(presence)
             attendance[raid_id] = raid_att
             log_amts[raid_id] += 1
-
-        for raid_id in attendance:
-            for player in attendance[raid_id]:
-                vals_missing = log_amts[raid_id] - len(attendance[raid_id][player])
-                attendance[raid_id][player] += [0] * vals_missing
+            for player in raid_att:
+                vals_missing = log_amts[raid_id] - len(raid_att[player])
+                raid_att[player] += [0]*vals_missing
 
         return attendance
 

--- a/backend.py
+++ b/backend.py
@@ -461,12 +461,14 @@ class Backend:
 
         attendance = collections.defaultdict(dict)
         log_amts = collections.defaultdict(int)
+        headers = collections.defaultdict(list)
         for raid in attendanceData:
             players = [p['name'] for p in raid['players']]
             raid_id = raid['zone']['id']
             presences = [p['presence'] for p in raid['players']]
             raid_att = attendance[raid_id]
             num_logs = log_amts[raid_id]
+            headers[raid_id].append(time.strftime('%d%m', raid['start_time']))
             for player, presence in zip(players, presences):
                 if player not in raid_att:
                     raid_att[player] = [0] * num_logs
@@ -477,7 +479,7 @@ class Backend:
                 vals_missing = log_amts[raid_id] - len(raid_att[player])
                 raid_att[player] += [0]*vals_missing
 
-        return attendance
+        return headers, attendance, token
 
 
 if __name__ == "__main__":

--- a/backend.py
+++ b/backend.py
@@ -15,7 +15,6 @@ import csv
 import time
 from dotenv import load_dotenv
 import os
-import numpy as np
 
 from lootitemdata import LootItemData
 

--- a/backend.py
+++ b/backend.py
@@ -479,7 +479,13 @@ class Backend:
                 vals_missing = log_amts[raid_id] - len(raid_att[player])
                 raid_att[player] += [0]*vals_missing
 
-        return headers, attendance, token
+        percentages = collections.defaultdict(dict)
+        for raid_id in attendance:
+            for player in attendance[raid_id]:
+                att = attendance[raid_id][player]
+                percentages[raid_id][player] = (att.count(1) + att.count(2)) / len(att)
+
+        return headers, attendance, token, percentages
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Re-formats the WCL data into a more manageable format. The format returned is quite simply some nested dictionaries. The top dictionary contains raid_ids as keys and dictionaries as values. Second level dictionary has player names as keys and np.arrays as values. The np arrays are 0 if the player wasn't present for that raid, 1 if player was persent and active, and 2 if player was present but benched. Testing not done as setting up WCL env variables and stuff is too much work for the time being...